### PR TITLE
Adding installation makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+ZOTERO_DATA ?= ~/Zotero
+
+.PHONY: install
+install:
+	@echo "Copying files to Zotero data directory $(ZOTERO_DATA)"
+	install -m644 engines.json $(ZOTERO_DATA)/locate/
+	install -m644 apa-meta-analysis.csl $(ZOTERO_DATA)/styles/
+	install -m644 apa-numeric.csl $(ZOTERO_DATA)/styles/
+	install -m644 apa-short-authors.csl $(ZOTERO_DATA)/styles/
+	install -m644 systematic-review-tables.csl $(ZOTERO_DATA)/styles/


### PR DESCRIPTION
Makefile assumes Zotero to live in $HOME/Zotero, which can be overriden. I do not know whether it would be possible to install csl files via wildcard, but the current form should suffice unless many more styles are being added.